### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -15,13 +15,10 @@ atom-text-editor[mini] {
     background-color: darken(@input-background-color, 5%);
   }
 
-  &, // <-- Deprecated. The `&,` can be removed once the Shadow DOM can't be turned off in the settings.
-  &::shadow {
-    .placeholder-text {
-      color: @text-color-subtle;
-    }
-    .selection .region {
-      background-color: @background-color-selected;
-    }
+  .placeholder-text {
+    color: @text-color-subtle;
+  }
+  .selection .region {
+    background-color: @background-color-selected;
   }
 }


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:
- Stop using `:host`.
- Stop using `atom-text-editor::shadow`.
- Prepend syntax class names with `syntax--`.

Ref: https://github.com/atom/atom/pull/12903
Closes #6
