### PR TITLE
Fix for files inheriting parent folder color in the tree view (list-tree) when involving a git status.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-theme-template",
   "theme": "ui",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "A short description of your UI theme",
   "keywords": [
     "ui",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui-theme-template",
   "theme": "ui",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A short description of your UI theme",
   "keywords": [
     "ui",

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -22,6 +22,7 @@
 
 // List Tree -------------------
 .list-tree {
+  color: @text-color;
   .selected {
     color: @text-color-selected;
   }


### PR DESCRIPTION
When a git status changes on a file, all other files in that folder are inheriting that color.
The line I added will keep the other files without a git status the correct color.

https://github.com/massivelines/neutral-gray-ui/issues/1