### PR TITLE
Remove unnecessary color reference

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -22,7 +22,7 @@
     }
 
 
-    // Modified Icon (the blue circle) -------------------
+    // Modified Icon (the circle) -------------------
     &.modified:not(:hover) .close-icon {
       top: 50%;
       right: @component-padding + 4px; // 4px -> half of icon size


### PR DESCRIPTION
Perhaps it would be an accessibility improvement to avoid a color only distinction here, and in any case the circle may not always be blue.